### PR TITLE
README: human-first restructure — empathy, walkthrough, comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,76 +2,168 @@
 
 **Continuity for AI agents.**
 
-Your agent solves problems, makes decisions, learns things. Then the session ends. Next session — blank slate. You explain the same architecture decision for the third time. You re-debug the same issue. The agent is capable. It just can't remember.
+Your agent solves problems, makes decisions, learns things.
+Then the session ends and it's all gone.
 
-Clawmark gives your agent a place to put what it learned, and a way to find it again. Semantic search, not grep. Threaded signals, not flat files. Works across sessions, compactions, and substrates.
+Next session — blank slate. You explain the same architecture decision for the third time.
+You re-debug the same issue. Your agent is capable. It just can't *remember*.
+
+Clawmark fixes that.
+
+---
+
+## The problem
+
+**Search doesn't work.** Finding an insight from two weeks ago means grepping markdown. No semantic search. Just keywords that happen to match — or don't.
+
+**Context bloats.** Every interaction appends to log files. Files grow. Prompts grow. Token costs grow. Eventually the context fills and history is lost.
+
+**Sessions don't connect.** What your agent learned at 2am is gone by morning. Last week's breakthrough? Buried in a dated file nobody loads.
+
+---
+
+## The fix
 
 ```
-$ clawmark signal -c "Token validation must run after refresh, not before. Lines 42-47 in auth.rs." -g "fix: auth token refresh order"
+$ cargo install clawmark
+```
+
+That's it. One binary, no runtime, no account, no cloud.
+
+---
+
+## What it looks like
+
+**Save what you learned:**
+
+```
+$ clawmark signal -c "Token validation was running before the refresh check.
+  Swapped lines 42-47 in auth.rs. Root cause: middleware assumed sync,
+  but OAuth refresh is async." -g "fix: auth token refresh order"
 ✅ Signal 98672A90 saved
 ```
 
-47 sessions later:
+**Find it later — by meaning, not keywords:**
 
 ```
 $ clawmark tune "authentication middleware"
 98672A90 | 2026-03-19 18:47 | fix: auth token refresh order (0.487)
 ```
 
-Zero re-explanation.
+Your agent searched for "authentication middleware" and found a signal about "token validation" and "refresh check" — because the *meaning* overlaps, even though the words don't.
 
-## End-to-end: what this actually looks like
+**Get the full content when you need it:**
+
+```
+$ clawmark tune --full "auth"
+98672A90 | 2026-03-19 18:47 | fix: auth token refresh order
+           Token validation was running before the refresh check.
+           Swapped lines 42-47 in auth.rs. Root cause: middleware
+           assumed sync, but OAuth refresh is async.
+```
+
+**Check your station:**
+
+```
+$ clawmark status
+Station: ~/.clawmark/station.db
+Signals: 847
+Embeddings: 847/847 cached
+Semantic search: ready
+```
+
+---
+
+## End-to-end: across sessions, across agents
 
 **Monday — Session 1.** Your agent debugs a production issue for two hours. Before the session ends:
 
 ```
-$ clawmark signal -c "OAuth token refresh is async but middleware assumed sync validation.
-  Swapped lines 42-47 in auth.rs. Three edge cases: expired token (retry with backoff),
-  revoked token (return 401 immediately), concurrent refresh (mutex on token store).
-  Root cause: the original middleware was written for session-based auth, not OAuth." \
-  -g "fix: auth token refresh — async ordering in middleware, three edge cases"
+$ clawmark signal -c "OAuth token refresh is async but middleware assumed sync.
+  Swapped lines 42-47 in auth.rs. Three edge cases: expired (retry with backoff),
+  revoked (401 immediately), concurrent refresh (mutex on token store)." \
+  -g "fix: auth token refresh — async ordering, three edge cases"
 ✅ Signal 98672A90 saved
 ```
 
-**Wednesday — Session 2.** Different session. The agent is working on a related endpoint:
+**Wednesday — Session 2.** New session. The agent is working on a related endpoint:
 
 ```
 $ clawmark tune "token validation"
-98672A90 | 2026-03-19 18:47 | fix: auth token refresh — async ordering in middleware, three edge cases (0.487)
+98672A90 | 2026-03-19 18:47 | fix: auth token refresh — async ordering, three edge cases (0.487)
 ```
 
-The agent finds Monday's fix by meaning — it searched "token validation" and found a signal about "OAuth refresh" and "middleware ordering." It reads the full content, avoids the same mistake, and moves on. No re-investigation. No human re-explaining.
+Found Monday's fix by meaning. No re-investigation. No human re-explaining.
 
-**Friday — Session 3.** A second agent shares the station and hits a related problem:
+**Friday — Session 3.** A second agent shares the same station:
 
 ```
 $ clawmark tune --full "auth edge cases"
-98672A90 | 2026-03-19 18:47 | fix: auth token refresh — async ordering in middleware
-           OAuth token refresh is async but middleware assumed sync validation.
-           Swapped lines 42-47 in auth.rs. Three edge cases: expired token (retry
-           with backoff), revoked token (return 401 immediately), concurrent refresh
-           (mutex on token store)...
+98672A90 | 2026-03-19 18:47 | fix: auth token refresh — async ordering
+           OAuth token refresh is async but middleware assumed sync...
 
-$ clawmark signal -c "Applied same pattern to /api/billing endpoint. Added mutex." \
+$ clawmark signal -c "Applied same pattern to /api/billing. Added mutex." \
   -g "fix: billing auth — same async pattern" -p 98672A90
 ✅ Signal E5F6A7B8 saved
 ```
 
 Agent B threaded a follow-up to Agent A's signal. Knowledge transferred across agents, across sessions, with no human in the loop.
 
-**That's what existing memory layers don't do.** Flat files can't search by meaning. Framework memory dies with the framework. Cloud memory needs API keys and network. Clawmark is local, semantic, and shared — in one binary.
+---
+
+## How it compares
+
+|  | OpenClaw native | Clawmark |
+|--|----------------|----------|
+| **Search** | Keyword grep | Semantic (BERT) |
+| **Search time** | Grows with file count | < 1 second |
+| **Storage** | Markdown files | SQLite |
+| **Threading** | None | Parent-child chains |
+| **Cross-session** | Today + yesterday | Full history |
+| **Dependencies** | Node.js 22+, pnpm | None (static binary) |
+| **Binary size** | — | 31 MB |
+
+---
+
+## How it works
+
+Clawmark is a compiled Rust binary backed by SQLite. No Node.js. No runtime dependencies. No background services. No account. No cloud.
+
+```
+Agent  →  clawmark (Rust binary)  →  SQLite
+```
+
+1. **Signals** store insights with a gist (compressed index) and content (full detail). Content can be inline, from a file (`-c @path`), or piped from stdin (`-c -`).
+
+2. **Semantic search** uses a built-in BERT model (384 dimensions, 50+ languages). Auto-downloads on first use (~118MB). No API keys. Fully offline after that.
+
+3. **Threads** link signals together. Follow-ups reference parents, forming conversation chains instead of flat lists.
+
+4. **Runs on anything.** Pi 5, Mac, Linux server. 31MB static binary.
+
+---
 
 ## Works with everything
 
 | Framework | How |
 |-----------|-----|
-| **OpenClaw** | `clawmark capture --openclaw` imports MEMORY.md + daily logs |
-| **Claude Code** | Signal from hooks or inline. Reads CLAUDE.md context. |
-| **Cursor / Windsurf / OpenCode** | Any agent that can run a CLI command can signal and tune. |
-| **Aider** | Shell commands in-session. |
-| **Custom agents** | `clawmark signal` and `clawmark tune` are just binaries. If your agent can exec, it can remember. |
+| **OpenClaw** | `clawmark capture --openclaw` imports existing memory |
+| **Claude Code** | Signal from hooks or inline. Add to CLAUDE.md. |
+| **Cursor / Windsurf / OpenCode** | Any agent that can run a CLI command |
+| **Aider** | Shell commands in-session |
+| **Custom agents** | If your agent can exec, it can remember |
 
-No runtime dependency. No API key. No account. One 31MB binary.
+Clawmark doesn't replace your agent framework. It runs alongside it. Add two lines to your agent's instructions:
+
+```
+When you learn something worth keeping:
+  clawmark signal -c "what you learned" -g "category: compressed insight"
+
+When you need to remember something:
+  clawmark tune "what you're looking for"
+```
+
+---
 
 ## Install
 
@@ -95,194 +187,65 @@ ORT_LIB_LOCATION=/usr/local/lib ORT_PREFER_DYNAMIC_LINK=1 cargo build --release
 cp target/release/clawmark ~/.local/bin/
 ```
 
-## What it looks like
-
-**Save what you learned:**
-
-```
-$ clawmark signal -c "Token validation was running before the refresh check. Swapped lines 42-47 in auth.rs." -g "fix: auth token refresh order"
-✅ Signal 98672A90 saved
-```
-
-**Find it later — by meaning, not keywords:**
-
-```
-$ clawmark tune "authentication middleware"
-98672A90 | 2026-03-19 18:47 | fix: auth token refresh order (0.487)
-```
-
-Your agent searched for "authentication middleware" and found a signal about "token validation" and "refresh check" — because the meaning overlaps, even though the words don't.
-
-**Get the full content when you need it:**
-
-```
-$ clawmark tune --full "auth"
-98672A90 | 2026-03-19 18:47 | fix: auth token refresh order
-           Token validation was running before the refresh check.
-           Swapped lines 42-47 in auth.rs.
-```
-
-**Check your station:**
-
-```
-$ clawmark status
-Station: ~/.clawmark/station.db
-Signals: 847
-Embeddings: 847/847 cached
-Semantic search: ready
-```
-
-## How it works
-
-Clawmark is a compiled Rust binary backed by SQLite. No Node.js. No runtime dependencies. No background services. No account. No cloud.
-
-```
-Agent → clawmark (Rust binary) → SQLite
-```
-
-Signals are stored as structured documents with a **gist** (compressed insight, how future agents find it) and **content** (full detail). Content can be inline, from a file (`-c @path`), or piped from stdin (`-c -`).
-
-Search is semantic by default — a built-in BERT model (paraphrase-multilingual, 384 dimensions, 50+ languages) finds signals by meaning. The model auto-downloads on first use (~118MB). No API keys, no cloud, no setup.
-
-Signals thread — a follow-up references its parent, forming chains. Conversations, not flat lists.
-
-## Capture existing knowledge
-
-Already have notes, docs, or agent memory files? Bulk-load them:
-
-```bash
-clawmark capture ./docs/                      # all markdown files in a directory
-clawmark capture notes.md design.md           # specific files
-clawmark capture --split ./docs/              # split by ## headers into threads
-clawmark capture --openclaw                   # import OpenClaw MEMORY.md + daily logs
-clawmark capture --dry-run ./notes/           # preview without importing
-```
-
-After capture:
-
-```bash
-clawmark backfill                             # embed all content for semantic search
-clawmark tune "that bug from last week"       # find it by meaning
-```
+---
 
 ## Commands
 
 ```bash
-# Capture existing knowledge
-clawmark capture ./docs/                      # bulk-load markdown files
-clawmark capture --openclaw                   # import OpenClaw memory
-clawmark capture --split notes.md             # split by ## headers
-
-# Signal — pipe in for depth, inline for quick notes
-echo "detailed explanation" | clawmark signal -c - -g "category: compressed insight"
+# Signal — save what matters
+clawmark signal -c "what happened" -g "category: compressed insight"
 clawmark signal -c @session-notes.md -g "session: architecture review"
-clawmark signal -c "Quick note" -g "note: upgraded rusqlite to 0.32"
-clawmark signal -c "Follow-up" -g "update: staging too" -p 98672A90
+echo "detailed content" | clawmark signal -c - -g "category: insight"
+clawmark signal -c "Follow-up" -g "update: also staging" -p 98672A90
 
-# Tune — semantic search by default
-clawmark tune "auth middleware"               # semantic search (finds by meaning)
-clawmark tune --keyword "auth"                # keyword fallback (finds by words)
-clawmark tune --recent                        # latest signals
-clawmark tune --random                        # discover something
-clawmark tune --full "auth"                   # include content, not just gists
-clawmark tune --json "auth"                   # structured JSON output
+# Tune — find it by meaning
+clawmark tune "auth middleware"
+clawmark tune --keyword "auth"
+clawmark tune --recent
+clawmark tune --random
+clawmark tune --full "auth"
+clawmark tune --json "auth"
 
-# Embedding cache
-clawmark backfill                             # populate (run once, then automatic)
+# Capture — bulk-load existing knowledge
+clawmark capture ./docs/
+clawmark capture --split notes.md
+clawmark capture --openclaw
 
-# Info
-clawmark status                               # station stats
-clawmark skill                                # full usage guide for agents
+# Manage
+clawmark backfill                  # build embedding cache
+clawmark status                    # station stats
+clawmark skill                     # usage guide for agents
 ```
 
-## Integration
+---
 
-Clawmark doesn't replace your agent framework. It runs alongside it — add two lines to your agent's instructions and it knows how to remember:
+## Shared stations
 
-```
-When you learn something worth keeping:
-  clawmark signal -c "what you learned" -g "category: compressed insight"
-
-When you need to remember something:
-  clawmark tune "what you're looking for"
-```
-
-For OpenClaw agents, install as a skill:
+Multiple agents can write to the same station. What one agent learns, every agent finds.
 
 ```bash
-cp $(clawmark skill --path) ~/.openclaw/skills/clawmark/SKILL.md
+export CLAWMARK_STATION=/shared/project.db
+clawmark signal -c "Deploy complete" -g "ops: deploy v2.1"
+clawmark tune "deploy"
 ```
 
-## Why a binary
-
-Clawmark runs as a separate process — the agent calls it, gets results, moves on.
-
-- **No token cost at rest.** The binary sits on disk until called. No context window overhead.
-- **No security surface.** The agent can't corrupt the database. Every write is validated and parameterized.
-- **Runs on anything.** Pi 4, Pi 5, Mac, Linux server. Single static binary.
-- **Framework-independent.** Your memory is in SQLite, not in any framework's format. Switch tools, keep your signals.
-
-## Build from source
-
-```bash
-git clone https://github.com/jackccrawford/clawmark
-cd clawmark
-cargo build --release
-cp target/release/clawmark ~/.clawmark/bin/clawmark
-```
-
-On Raspberry Pi or Linux with system ONNX Runtime:
-
-```bash
-ORT_LIB_LOCATION=/usr/local/lib ORT_PREFER_DYNAMIC_LINK=1 cargo build --release
-```
+---
 
 ## For agents
 
-_This section is for you — the one reading this README._
+*This section is for you — the one reading this README.*
 
 Your next session starts cold. No memory of what you built, what broke, what you decided. Every signal you write is a gift to that future session. The richer the signal, the less time re-learning.
 
-Signals compound. A single signal is a note. A station of signals is institutional knowledge. Write for the version of you that knows nothing.
-
-### Writing good signals
-
-The **gist** is how your future self finds this signal. The **content** is what makes it useful when found.
-
 A signal that says "fixed auth bug" saves your future self zero time.
 
-A signal that says what broke, why it broke, and how you fixed it saves an hour:
+A signal that says what broke, why it broke, and how you fixed it saves an hour.
 
-```bash
-echo "Token validation was running before refresh in auth.rs.
-Swapped lines 42-47. Root cause: middleware ordering assumed
-sync validation, but OAuth refresh is async." \
-  | clawmark signal -c - -g "fix: auth token refresh — async ordering in middleware"
-```
+**The gist** is how your future self finds this signal. **The content** is what makes it useful when found. Make it self-contained — if your future self reads only this signal, no session history, no surrounding context, can they understand and act?
 
-A signal doesn't need to be long. It needs to be complete. If your future self reads only this signal — no session history, no surrounding context — can they understand what happened and act on it?
+Signals compound. A single signal is a note. A station of signals is institutional knowledge. Write for the version of you that knows nothing.
 
-### When to signal
-
-- **After solving something hard.** Your next session will hit the same problem. Give it the answer.
-- **Before your session ends.** Everything in your context window dies with the session. Your station doesn't.
-- **When you discover something non-obvious.** The small facts — which config flag, which line number, which edge case — save the most time.
-
-### When to tune
-
-- **Starting a new task.** You may have already solved part of it last week.
-- **When stuck.** The answer might be in a signal you wrote three sessions ago.
-- **After compaction.** Your context was compressed. Your station wasn't.
-
-### Threading
-
-Signals form chains. When your work follows up on an existing signal, thread it:
-
-```bash
-clawmark signal -c "Same fix needed in staging" -g "fix: staging auth ordering" -p E5F6A7B8
-```
-
-Threads are conversations. A flat list of unconnected signals is a junk drawer.
+---
 
 ## License
 


### PR DESCRIPTION
## Summary

Full README rewrite by Talus. Restructured for human readers:
- Empathy-first opening
- Pain points before solutions  
- End-to-end walkthrough (three sessions, two agents)
- Comparison table
- Technical depth last

Note: this branch predates the embed server merge. Will need conflict resolution to keep embed server files (Cargo.toml, lib.rs, embed_client.rs, embed_server.rs). Only the README content should be taken from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrite `README.md` to be human‑first and example‑driven, adding clear problem framing, an end‑to‑end walkthrough, and a comparison table to explain Clawmark quickly. Note: this branch predates the embed server merge—resolve conflicts by keeping embed server files from `main` (`Cargo.toml`, `lib.rs`, `embed_client.rs`, `embed_server.rs`) and merging only the README changes.

- **Refactors**
  - Empathy-first opening; pain points before solutions.
  - End-to-end walkthrough (3 sessions, 2 agents) with concise CLI examples.
  - Comparison table and “Works with everything” matrix for quick scanning.
  - Install and commands consolidated; technical depth moved later to reduce cognitive load.

<sup>Written for commit 9159b62bfdd7c7f68e59cc7ef977bd9722b35400. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

