### PR TITLE
Geniuz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clawmark"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "clap",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -127,9 +127,22 @@ pub enum Command {
     /// Show station stats
     Status,
 
-    /// Run as MCP server for Claude Desktop (stdio transport)
+    /// MCP server for Claude Desktop — run, install, or check status
+    #[command(subcommand)]
+    Mcp(McpCommand),
+}
+
+#[derive(Subcommand)]
+pub enum McpCommand {
+    /// Run as MCP server (stdio transport — used by Claude Desktop internally)
+    Serve,
+
+    /// Install Geniuz into Claude Desktop config
     #[command(
-        after_help = "Runs clawmark as an MCP server over stdio. Claude Desktop connects\nto this and gets remember/recall/recall_recent tools.\n\nAdd to Claude Desktop config:\n  ~/.config/Claude/claude_desktop_config.json (Linux)\n  ~/Library/Application Support/Claude/claude_desktop_config.json (Mac)\n\n{\n  \"mcpServers\": {\n    \"geniuz\": {\n      \"command\": \"clawmark\",\n      \"args\": [\"mcp\"]\n    }\n  }\n}"
+        after_help = "Adds clawmark as an MCP server in Claude Desktop's config file.\nAfter running this, restart Claude Desktop to activate Geniuz.\n\nYour Claude will have three new tools: remember, recall, recall_recent."
     )]
-    Mcp,
+    Install,
+
+    /// Check if Geniuz is configured in Claude Desktop
+    Status,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,4 +125,10 @@ pub enum Command {
 
     /// Show station stats
     Status,
+
+    /// Run as MCP server for Claude Desktop (stdio transport)
+    #[command(
+        after_help = "Runs clawmark as an MCP server over stdio. Claude Desktop connects\nto this and gets remember/recall/recall_recent tools.\n\nAdd to Claude Desktop config:\n  ~/.config/Claude/claude_desktop_config.json (Linux)\n  ~/Library/Application Support/Claude/claude_desktop_config.json (Mac)\n\n{\n  \"mcpServers\": {\n    \"geniuz\": {\n      \"command\": \"clawmark\",\n      \"args\": [\"mcp\"]\n    }\n  }\n}"
+    )]
+    Mcp,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@ use clap::{Parser, Subcommand};
     version,
     about = "Continuity for AI agents",
     long_about = "CLAWMARK: Continuity for AI agents.\n\nSemantic search across sessions. Works with any agent framework:\nOpenClaw, Claude Code, Aider, Cursor, LangChain, custom agents —\nanything that can run a shell command.\n\nMultiple agents can share a station for coordinated continuity.",
+    before_help = "Start here: 'clawmark tune --recent' to see what's in your station.",
     after_help = "Examples:\n  clawmark signal -c \"Fixed the auth bug\" -g \"fix: token refresh\"\n  clawmark tune \"auth\"                       Semantic search\n  clawmark tune --recent                     Latest signals\n  clawmark capture ./notes/                  Bulk-load markdown files\n  clawmark capture --openclaw                Import OpenClaw memory\n  clawmark backfill                          Build embedding cache\n\nStation: Defaults to ~/.clawmark/station.db\n  Override: CLAWMARK_STATION=/path/to/shared.db clawmark signal ...\n  Multiple agents can write to the same station for shared memory.\n\nUse \"clawmark [command] --help\" for more information."
 )]
 pub struct Cli {
@@ -32,32 +33,6 @@ impl Cli {
 
 #[derive(Subcommand)]
 pub enum Command {
-    /// Capture files or directories into your station
-    #[command(
-        arg_required_else_help = true,
-        after_help = "Examples:\n  clawmark capture notes.md                              Single file\n  clawmark capture ./docs/                               All .md files in directory\n  clawmark capture *.md                                  Shell glob\n  clawmark capture --split notes.md                      Split by ## headers\n  clawmark capture --gist-prefix \"docs:\" a.md            Prefix all gists\n  clawmark capture --openclaw ~/.openclaw/workspace      Import OpenClaw memory\n  clawmark capture --dry-run ./notes/                    Preview without importing\n\nEach file becomes a signal. With --split, each ## section becomes\na threaded signal under the file's root signal.\n\nWith --openclaw, reads MEMORY.md and memory/YYYY-MM-DD.md files,\npreserving timestamps and threading daily sections."
-    )]
-    Capture {
-        /// Files or directories to capture (not used with --openclaw)
-        paths: Vec<String>,
-
-        /// Import an OpenClaw workspace
-        #[arg(long, conflicts_with = "paths")]
-        openclaw: Option<Option<String>>,
-
-        /// Split files by ## headers into threaded signals
-        #[arg(long)]
-        split: bool,
-
-        /// Prefix for auto-generated gists
-        #[arg(long)]
-        gist_prefix: Option<String>,
-
-        /// Preview what would be captured without writing
-        #[arg(long)]
-        dry_run: bool,
-    },
-
     /// Transmit a signal to your station
     #[command(
         arg_required_else_help = true,
@@ -112,6 +87,32 @@ pub enum Command {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+    },
+
+    /// Capture files or directories into your station
+    #[command(
+        arg_required_else_help = true,
+        after_help = "Examples:\n  clawmark capture notes.md                              Single file\n  clawmark capture ./docs/                               All .md files in directory\n  clawmark capture *.md                                  Shell glob\n  clawmark capture --split notes.md                      Split by ## headers\n  clawmark capture --gist-prefix \"docs:\" a.md            Prefix all gists\n  clawmark capture --openclaw ~/.openclaw/workspace      Import OpenClaw memory\n  clawmark capture --dry-run ./notes/                    Preview without importing\n\nEach file becomes a signal. With --split, each ## section becomes\na threaded signal under the file's root signal.\n\nWith --openclaw, reads MEMORY.md and memory/YYYY-MM-DD.md files,\npreserving timestamps and threading daily sections."
+    )]
+    Capture {
+        /// Files or directories to capture (not used with --openclaw)
+        paths: Vec<String>,
+
+        /// Import an OpenClaw workspace
+        #[arg(long, conflicts_with = "paths")]
+        openclaw: Option<Option<String>>,
+
+        /// Split files by ## headers into threaded signals
+        #[arg(long)]
+        split: bool,
+
+        /// Prefix for auto-generated gists
+        #[arg(long)]
+        gist_prefix: Option<String>,
+
+        /// Preview what would be captured without writing
+        #[arg(long)]
+        dry_run: bool,
     },
 
     /// Build embedding cache for semantic search

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,9 +348,20 @@ fn run(cli: Cli) -> Result<String, String> {
             Ok(lines.join("\n"))
         }
 
-        Command::Mcp => {
-            mcp::serve();
-            Ok(String::new())
+        Command::Mcp(mcp_cmd) => {
+            use cli::McpCommand;
+            match mcp_cmd {
+                McpCommand::Serve => {
+                    mcp::serve();
+                    Ok(String::new())
+                }
+                McpCommand::Install => {
+                    mcp::install()
+                }
+                McpCommand::Status => {
+                    mcp::status()
+                }
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod adapter;
 mod cli;
 mod db;
+mod mcp;
 
 use clap::FromArgMatches;
 use cli::{Cli, Command};
@@ -345,6 +346,11 @@ fn run(cli: Cli) -> Result<String, String> {
                 lines.push("Semantic search: ready".to_string());
             }
             Ok(lines.join("\n"))
+        }
+
+        Command::Mcp => {
+            mcp::serve();
+            Ok(String::new())
         }
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -270,3 +270,133 @@ pub fn serve() {
         let _ = stdout.flush();
     }
 }
+
+// =============================================================================
+// Install / Status
+// =============================================================================
+
+fn config_path() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    if cfg!(target_os = "macos") {
+        std::path::PathBuf::from(home)
+            .join("Library/Application Support/Claude/claude_desktop_config.json")
+    } else {
+        std::path::PathBuf::from(home)
+            .join(".config/Claude/claude_desktop_config.json")
+    }
+}
+
+fn clawmark_binary_path() -> String {
+    // Use the currently running binary's path
+    std::env::current_exe()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| "clawmark".to_string())
+}
+
+pub fn install() -> Result<String, String> {
+    let config_file = config_path();
+
+    // Read existing config or create new
+    let mut config: serde_json::Value = if config_file.exists() {
+        let content = std::fs::read_to_string(&config_file)
+            .map_err(|e| format!("Failed to read {}: {}", config_file.display(), e))?;
+        serde_json::from_str(&content)
+            .map_err(|e| format!("Failed to parse config: {}", e))?
+    } else {
+        // Create parent directories
+        if let Some(parent) = config_file.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create config directory: {}", e))?;
+        }
+        serde_json::json!({})
+    };
+
+    // Ensure mcpServers exists
+    if config.get("mcpServers").is_none() {
+        config["mcpServers"] = serde_json::json!({});
+    }
+
+    let binary = clawmark_binary_path();
+
+    // Add geniuz server
+    config["mcpServers"]["geniuz"] = serde_json::json!({
+        "command": binary,
+        "args": ["mcp", "serve"]
+    });
+
+    // Write back
+    let formatted = serde_json::to_string_pretty(&config)
+        .map_err(|e| format!("Failed to serialize config: {}", e))?;
+    std::fs::write(&config_file, &formatted)
+        .map_err(|e| format!("Failed to write {}: {}", config_file.display(), e))?;
+
+    let mut lines = vec![
+        "✅ Geniuz installed in Claude Desktop.".to_string(),
+        String::new(),
+        format!("  Config: {}", config_file.display()),
+        format!("  Binary: {}", binary),
+        String::new(),
+        "  Restart Claude Desktop to activate.".to_string(),
+        "  Your Claude will have: remember, recall, recall_recent".to_string(),
+    ];
+
+    // Check if station exists
+    let station = crate::default_station_path();
+    if station.exists() {
+        let db = crate::get_db()?;
+        let count = db.count().unwrap_or(0);
+        if count > 0 {
+            lines.push(String::new());
+            lines.push(format!("  Station has {} existing memories — Claude will find them.", count));
+        }
+    }
+
+    Ok(lines.join("\n"))
+}
+
+pub fn status() -> Result<String, String> {
+    let config_file = config_path();
+
+    if !config_file.exists() {
+        return Ok("Claude Desktop config not found. Run 'clawmark mcp install' first.".to_string());
+    }
+
+    let content = std::fs::read_to_string(&config_file)
+        .map_err(|e| format!("Failed to read config: {}", e))?;
+    let config: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| format!("Failed to parse config: {}", e))?;
+
+    let installed = config.get("mcpServers")
+        .and_then(|s| s.get("geniuz"))
+        .is_some();
+
+    let mut lines = vec![
+        format!("Config: {}", config_file.display()),
+        format!("Geniuz: {}", if installed { "installed" } else { "not installed" }),
+    ];
+
+    if installed {
+        if let Some(cmd) = config["mcpServers"]["geniuz"].get("command").and_then(|c| c.as_str()) {
+            lines.push(format!("Binary: {}", cmd));
+        }
+    }
+
+    // Station info
+    let station = crate::default_station_path();
+    if station.exists() {
+        if let Ok(db) = crate::get_db() {
+            let count = db.count().unwrap_or(0);
+            let embeddings = db.embedding_count().unwrap_or(0);
+            lines.push(format!("Station: {} ({} memories, {}/{} embedded)", station.display(), count, embeddings, count));
+        }
+    } else {
+        lines.push("Station: not created yet (will be created on first remember)".to_string());
+    }
+
+    if !installed {
+        lines.push(String::new());
+        lines.push("Run 'clawmark mcp install' to add Geniuz to Claude Desktop.".to_string());
+    }
+
+    Ok(lines.join("\n"))
+}

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,272 @@
+//! MCP server over stdio — exposes clawmark as remember/recall tools
+//!
+//! Claude Desktop connects via stdio transport. The agent gets three
+//! human-friendly tools that wrap clawmark's signal/tune operations.
+//!
+//! Tool descriptions guide the model toward proactive memory use —
+//! recalling on startup, remembering during conversation.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::io::{self, BufRead, Write};
+
+use crate::db::{DatabaseManager, SignalEntry};
+
+// =============================================================================
+// MCP Protocol Types
+// =============================================================================
+
+#[derive(Deserialize)]
+struct JsonRpcRequest {
+    #[allow(dead_code)]
+    jsonrpc: String,
+    id: Option<Value>,
+    method: String,
+    #[serde(default)]
+    params: Value,
+}
+
+#[derive(Serialize)]
+struct JsonRpcResponse {
+    jsonrpc: String,
+    id: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<Value>,
+}
+
+fn success(id: Value, result: Value) -> JsonRpcResponse {
+    JsonRpcResponse { jsonrpc: "2.0".to_string(), id, result: Some(result), error: None }
+}
+
+fn error_response(id: Value, code: i64, message: &str) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: "2.0".to_string(), id, result: None,
+        error: Some(json!({ "code": code, "message": message })),
+    }
+}
+
+fn tool_result(id: Value, text: &str, is_error: bool) -> JsonRpcResponse {
+    success(id, json!({
+        "content": [{ "type": "text", "text": text }],
+        "isError": is_error
+    }))
+}
+
+// =============================================================================
+// Tool Definitions
+// =============================================================================
+
+fn tool_definitions() -> Value {
+    json!({
+        "tools": [
+            {
+                "name": "remember",
+                "description": "Save something worth remembering for future sessions. Use this when you learn something important about the user — their preferences, decisions, client details, project context, or anything they would not want to repeat. Your future self will find it by meaning, not keywords. Signal more than you think you should — storage is free, forgetting is expensive.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "type": "string",
+                            "description": "The full detail. Write for a future you that knows nothing about this session. Include names, numbers, decisions, reasoning, context."
+                        },
+                        "gist": {
+                            "type": "string",
+                            "description": "A one-line summary for finding this later. Format: 'category: key insight'. Example: 'client: Maria — Q2 retention focus, $40K budget'"
+                        },
+                        "thread": {
+                            "type": "string",
+                            "description": "Optional. Short UUID of a previous memory to thread this to. Builds chains — prospect to client, draft to final, problem to solution."
+                        }
+                    },
+                    "required": ["content", "gist"]
+                }
+            },
+            {
+                "name": "recall",
+                "description": "Search your memories by meaning. Use this at the START of every conversation to check what you already know about the topic or the user. Also use it whenever you need context from previous sessions. The search finds related memories even when the words are different — 'budget priorities' finds memories about 'retention focus, $40K'. Use this proactively and often.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "What you are looking for. A topic, a name, a concept. Semantic search finds related memories even if the exact words differ."
+                        },
+                        "full": {
+                            "type": "boolean",
+                            "description": "If true, returns full content of each memory. Default false (gist summaries only)."
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Maximum results. Default 10."
+                        }
+                    },
+                    "required": ["query"]
+                }
+            },
+            {
+                "name": "recall_recent",
+                "description": "Get the most recent memories. Use this at the START of every conversation to see what happened in recent sessions. This is how you orient yourself — what was the user working on? What decisions were made? What context matters right now?",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "limit": {
+                            "type": "integer",
+                            "description": "Number of recent memories to return. Default 5."
+                        },
+                        "full": {
+                            "type": "boolean",
+                            "description": "If true, returns full content. Default false (gist summaries only)."
+                        }
+                    }
+                }
+            }
+        ]
+    })
+}
+
+// =============================================================================
+// Tool Execution
+// =============================================================================
+
+fn execute_remember(db: &DatabaseManager, params: &Value) -> (String, bool) {
+    let content = match params.get("content").and_then(|c| c.as_str()) {
+        Some(c) => c,
+        None => return ("Error: content is required".to_string(), true),
+    };
+    let gist = params.get("gist").and_then(|g| g.as_str());
+    let thread = params.get("thread").and_then(|t| t.as_str());
+
+    match db.signal_with_backend(content, gist, thread, None, None) {
+        Ok(uuid) => (format!("Remembered ({})", uuid), false),
+        Err(e) => (format!("Error: {}", e), true),
+    }
+}
+
+fn execute_recall(db: &DatabaseManager, params: &Value) -> (String, bool) {
+    let query = match params.get("query").and_then(|q| q.as_str()) {
+        Some(q) => q,
+        None => return ("Error: query is required".to_string(), true),
+    };
+    let full = params.get("full").and_then(|f| f.as_bool()).unwrap_or(false);
+    let limit = params.get("limit").and_then(|l| l.as_u64()).unwrap_or(10) as usize;
+
+    // Semantic first, keyword fallback
+    let results = match db.semantic_search(query, limit) {
+        Ok(r) if !r.is_empty() => r,
+        _ => match db.keyword_search(query, limit) {
+            Ok(r) => r,
+            Err(e) => return (format!("Error: {}", e), true),
+        },
+    };
+
+    if results.is_empty() {
+        return ("No memories found for that query.".to_string(), false);
+    }
+
+    (format_entries(&results, full, db), false)
+}
+
+fn execute_recall_recent(db: &DatabaseManager, params: &Value) -> (String, bool) {
+    let limit = params.get("limit").and_then(|l| l.as_u64()).unwrap_or(5) as usize;
+    let full = params.get("full").and_then(|f| f.as_bool()).unwrap_or(false);
+
+    match db.recent(limit) {
+        Ok(entries) if entries.is_empty() => {
+            ("No memories yet. This is a fresh start.".to_string(), false)
+        }
+        Ok(entries) => (format_entries(&entries, full, db), false),
+        Err(e) => (format!("Error: {}", e), true),
+    }
+}
+
+fn format_entries(entries: &[SignalEntry], full: bool, db: &DatabaseManager) -> String {
+    let mut lines = Vec::new();
+    for e in entries {
+        let ts = crate::shorten_ts(&e.created_at);
+        let score_str = e.score.map(|s| format!(" ({:.2})", s)).unwrap_or_default();
+        if full {
+            let content = db.get_full_content(&e.signal_uuid)
+                .ok().flatten().unwrap_or_default();
+            lines.push(format!("{} | {} | {}{}\n  {}", &e.signal_uuid[..8], ts, e.gist, score_str, content));
+        } else {
+            lines.push(format!("{} | {} | {}{}", &e.signal_uuid[..8], ts, e.gist, score_str));
+        }
+    }
+    lines.join("\n")
+}
+
+// =============================================================================
+// MCP Server Loop
+// =============================================================================
+
+pub fn serve() {
+    let db = match crate::get_db() {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("[geniuz] Failed to open station: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let request: JsonRpcRequest = match serde_json::from_str(&line) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+
+        let id = request.id.clone().unwrap_or(Value::Null);
+
+        let response = match request.method.as_str() {
+            "initialize" => {
+                success(id, json!({
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": { "tools": {} },
+                    "serverInfo": {
+                        "name": "geniuz",
+                        "version": env!("CARGO_PKG_VERSION")
+                    }
+                }))
+            }
+
+            "notifications/initialized" => continue,
+
+            "tools/list" => success(id, tool_definitions()),
+
+            "tools/call" => {
+                let tool_name = request.params.get("name")
+                    .and_then(|n| n.as_str()).unwrap_or("");
+                let arguments = request.params.get("arguments")
+                    .cloned().unwrap_or(json!({}));
+
+                let (text, is_error) = match tool_name {
+                    "remember" => execute_remember(&db, &arguments),
+                    "recall" => execute_recall(&db, &arguments),
+                    "recall_recent" => execute_recall_recent(&db, &arguments),
+                    _ => (format!("Unknown tool: {}", tool_name), true),
+                };
+
+                tool_result(id, &text, is_error)
+            }
+
+            _ => error_response(id, -32601, &format!("Method not found: {}", request.method)),
+        };
+
+        let json_str = serde_json::to_string(&response).unwrap_or_default();
+        let _ = writeln!(stdout, "{}", json_str);
+        let _ = stdout.flush();
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an MCP server mode (“Geniuz”) to `clawmark` for Claude Desktop with proactive memory tools and a one-command install. Also improves CLI help with a start-here tip and command order.

- **New Features**
  - `clawmark mcp serve`: MCP server over stdio for Claude Desktop.
  - Tools: `remember(content, gist, thread?)`, `recall(query, full?, limit?)`, `recall_recent(limit?, full?)`.
  - Semantic search with keyword fallback; recent fetch API.
  - `clawmark mcp install`: writes config to Claude Desktop and detects binary path.
  - `clawmark mcp status`: shows install state and station health.
  - CLI: adds a “start here” tip and surfaces everyday commands first.

- **Migration**
  - Run `clawmark mcp install`.
  - Restart Claude Desktop.
  - Claude gains: `remember`, `recall`, `recall_recent`.

<sup>Written for commit a0dc5df40dc7f23f37548f07ad0a7fc3f61b6663. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

