### PR TITLE
Cross-platform IPC: UDS on Unix, Named Pipes on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ xcuserdata/
 # Build artifacts
 *.dmg
 desktop/build/
+
+# Built installers (uploaded to GitHub releases)
+Geniuz-Setup.exe
+installer/windows/output/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +569,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "interprocess",
  "ort",
  "regex",
  "rusqlite",
@@ -818,6 +825,19 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "interprocess"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+dependencies = [
+ "doctest-file",
+ "libc",
+ "recvmsg",
+ "widestring",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1343,6 +1363,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_users"
@@ -2034,6 +2060,12 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ dirs = "5"
 ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "api-17", "download-binaries", "copy-dylibs", "tls-native"] }
 tokenizers = { version = "0.21", default-features = false, features = ["onig"] }
 ureq = { version = "3", features = ["json"] }
+interprocess = "2"

--- a/installer/windows/Geniuz.iss
+++ b/installer/windows/Geniuz.iss
@@ -1,0 +1,89 @@
+; Geniuz Free for Windows — Inno Setup installer script
+; Per-user install (no admin), matches the philosophy of "your AI on your machine"
+
+#define MyAppName "Geniuz"
+#define MyAppVersion "1.0.1"
+#define MyAppPublisher "Managed Ventures LLC"
+#define MyAppURL "https://geniuz.life"
+#define MyAppExeName "geniuz.exe"
+#define MyAppDescription "Your AI remembers now."
+
+[Setup]
+AppId={{B0EA9F1E-5C2C-4C1B-9F4A-7D3E1B2C9A7E}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppVerName={#MyAppName} {#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
+AppComments={#MyAppDescription}
+DefaultDirName={localappdata}\Programs\Geniuz
+DefaultGroupName=Geniuz
+DisableProgramGroupPage=yes
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
+OutputDir=output
+OutputBaseFilename=Geniuz-Setup
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+UninstallDisplayName={#MyAppName}
+UninstallDisplayIcon={app}\{#MyAppExeName}
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Files]
+Source: "geniuz.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "geniuz-embed.exe"; DestDir: "{app}"; Flags: ignoreversion
+
+[Registry]
+; Add install dir to user PATH (only if not already present)
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; \
+  ValueData: "{olddata};{app}"; \
+  Check: NeedsAddPath('{app}')
+
+[Run]
+; Wire Claude Desktop MCP config (runs in user context — writes to %APPDATA%)
+Filename: "{app}\{#MyAppExeName}"; Parameters: "mcp install"; \
+  StatusMsg: "Configuring Claude Desktop integration..."; \
+  Flags: runhidden
+
+[Code]
+function NeedsAddPath(Param: string): Boolean;
+var
+  OrigPath: string;
+begin
+  if not RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', OrigPath) then
+  begin
+    Result := True;
+    exit;
+  end;
+  // Treat case-insensitively, match exact entry boundaries
+  Result := Pos(';' + LowerCase(Param) + ';', ';' + LowerCase(OrigPath) + ';') = 0;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  OrigPath: string;
+  AppDir: string;
+  NewPath: string;
+begin
+  if CurUninstallStep = usUninstall then
+  begin
+    AppDir := ExpandConstant('{app}');
+    if RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', OrigPath) then
+    begin
+      // Remove ;AppDir from PATH (idempotent, case-insensitive).
+      // StringChangeEx mutates the var-string and returns Integer (count).
+      NewPath := OrigPath;
+      StringChangeEx(NewPath, ';' + AppDir, '', True);
+      StringChangeEx(NewPath, AppDir + ';', '', True);
+      StringChangeEx(NewPath, AppDir, '', True);
+      RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', NewPath);
+    end;
+  end;
+end;

--- a/installer/windows/README.md
+++ b/installer/windows/README.md
@@ -1,0 +1,49 @@
+# Windows installer
+
+Inno Setup script for building `Geniuz-Setup.exe` — per-user Windows installer.
+
+## Build
+
+Requires Inno Setup 6+ (`ISCC.exe`). Easiest install on Windows:
+
+```powershell
+choco install innosetup -y
+```
+
+Then from this directory, with `geniuz.exe` and `geniuz-embed.exe` from
+`target/x86_64-pc-windows-msvc/release/` copied alongside `Geniuz.iss`:
+
+```powershell
+cd path\to\staging-dir
+& 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe' Geniuz.iss
+```
+
+Output: `output\Geniuz-Setup.exe` (~13 MB, LZMA2 compressed).
+
+## What it does
+
+- Per-user install (no admin required)
+- Installs to `%LOCALAPPDATA%\Programs\Geniuz\`
+- Adds install dir to user PATH (idempotent)
+- Runs `geniuz mcp install` postinstall — wires Claude Desktop config at
+  `%APPDATA%\Claude\claude_desktop_config.json`
+- Generates uninstaller (`unins000.exe`) that reverses everything but
+  preserves `~/.geniuz/memory.db` (user data is sacred)
+
+## Why per-user, not Program Files
+
+Per-user means no admin elevation, no UAC prompt, faster install. Geniuz is a
+personal-memory tool — installing it under one Windows account doesn't make
+sense to share with another. Mac install pattern is the same (`~/Applications`
+or `/Applications` is a user choice, MCP config is per-user).
+
+## Why Inno Setup, not NSIS or MSI
+
+Tried NSIS first — direct downloads from SourceForge consistently failed
+across multiple mirrors (corrupted bytes, 404s). Tried Inno Setup direct
+downloads from jrsoftware.org — same problem (404s on multiple version URLs).
+Chocolatey absorbed the URL drift cleanly. Inno Setup also has nicer default
+UX than NSIS for non-technical users.
+
+MSI via WiX would be more enterprise-friendly but heavier toolchain. Inno
+Setup is the right balance for a consumer product shipped to individual users.

--- a/src/embed_client.rs
+++ b/src/embed_client.rs
@@ -1,49 +1,49 @@
-//! Client for geniuz-embed socket server
+//! Client for geniuz-embed IPC server
 //!
-//! Try socket first. If unavailable, fall back to inline ONNX loading.
+//! Try connecting first. If unavailable, fall back to inline ONNX loading.
 //! If GENIUZ_EMBED_SPAWN=1, auto-spawn the server on first use.
+//!
+//! Cross-platform IPC via interprocess crate:
+//!   Unix/macOS: Unix domain socket
+//!   Windows:    Named pipe
+//! No network surface on any platform — silent to firewalls and netstat.
 
 use std::io::{Read, Write};
-use std::os::unix::net::UnixStream;
-use std::path::Path;
+use interprocess::local_socket::{
+    prelude::*, GenericNamespaced, Stream, ToNsName,
+};
 
-const DEFAULT_SOCKET: &str = "/tmp/geniuz-embed.sock";
+const DEFAULT_NAME: &str = "geniuz-embed.sock";
 const EMBEDDING_BYTES: usize = 384 * 4;
 
-/// Embed text via the socket server. Returns None if server unavailable.
-pub fn embed_via_socket(text: &str) -> Option<Vec<f32>> {
-    let socket_path = std::env::var("GENIUZ_EMBED_SOCKET")
-        .unwrap_or_else(|_| DEFAULT_SOCKET.to_string());
+fn ipc_name() -> String {
+    std::env::var("GENIUZ_EMBED_SOCKET")
+        .unwrap_or_else(|_| DEFAULT_NAME.to_string())
+}
 
-    if Path::new(&socket_path).exists() {
-        // Socket file exists — try connecting. If it fails, it's stale.
-        match UnixStream::connect(&socket_path) {
-            Ok(s) => {
-                s.set_read_timeout(Some(std::time::Duration::from_secs(2))).ok()?;
-                // Connected — use this stream below
-                return embed_on_stream(s, text);
-            }
-            Err(_) => {
-                // Stale socket — remove it
-                let _ = std::fs::remove_file(&socket_path);
-            }
-        }
+/// Embed text via the local IPC server. Returns None if server unavailable.
+pub fn embed_via_socket(text: &str) -> Option<Vec<f32>> {
+    let name = ipc_name();
+    let ns_name = name.as_str().to_ns_name::<GenericNamespaced>().ok()?;
+
+    // Try connecting first
+    if let Ok(s) = Stream::connect(ns_name.clone()) {
+        return embed_on_stream(s, text);
     }
 
-    // No socket (or stale socket removed) — try auto-spawning
+    // Connection failed — try auto-spawning
     if std::env::var("GENIUZ_EMBED_SPAWN").ok().as_deref() == Some("1") {
-        spawn_server(&socket_path);
+        spawn_server(&name);
     } else {
         return None;
     }
 
-    let stream = UnixStream::connect(&socket_path).ok()?;
-    stream.set_read_timeout(Some(std::time::Duration::from_secs(2))).ok()?;
+    let stream = Stream::connect(ns_name).ok()?;
     embed_on_stream(stream, text)
 }
 
 /// Send text over a connected stream, receive embedding back
-fn embed_on_stream(mut stream: UnixStream, text: &str) -> Option<Vec<f32>> {
+fn embed_on_stream(mut stream: Stream, text: &str) -> Option<Vec<f32>> {
     let text_bytes = text.as_bytes();
     let len = text_bytes.len() as u32;
     stream.write_all(&len.to_le_bytes()).ok()?;
@@ -59,30 +59,32 @@ fn embed_on_stream(mut stream: UnixStream, text: &str) -> Option<Vec<f32>> {
 }
 
 /// Try to spawn geniuz-embed in background
-fn spawn_server(socket_path: &str) {
-    // Find the binary next to ourselves
+fn spawn_server(name: &str) {
     let self_path = std::env::current_exe().ok();
+    let embed_name = if cfg!(windows) { "geniuz-embed.exe" } else { "geniuz-embed" };
     let embed_path = self_path.as_ref()
         .and_then(|p| p.parent())
-        .map(|dir| dir.join("geniuz-embed"));
+        .map(|dir| dir.join(embed_name));
 
     let binary = match embed_path {
         Some(p) if p.exists() => p,
-        _ => return, // Can't find the binary, fall back to inline
+        _ => return,
     };
 
-    // Spawn detached
     let _ = std::process::Command::new(binary)
-        .env("GENIUZ_EMBED_SOCKET", socket_path)
+        .env("GENIUZ_EMBED_SOCKET", name)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .spawn();
 
-    // Wait for socket to appear (up to 5 seconds)
+    // Wait for server to start listening (up to 5 seconds)
+    let ns_name = match name.to_ns_name::<GenericNamespaced>() {
+        Ok(n) => n,
+        Err(_) => return,
+    };
     for _ in 0..50 {
-        if Path::new(socket_path).exists() {
-            std::thread::sleep(std::time::Duration::from_millis(100));
+        if Stream::connect(ns_name.clone()).is_ok() {
             return;
         }
         std::thread::sleep(std::time::Duration::from_millis(100));

--- a/src/embed_server.rs
+++ b/src/embed_server.rs
@@ -1,35 +1,44 @@
 //! geniuz-embed — keeps the ONNX session warm for fast embedding
 //!
-//! Unix domain socket server at /tmp/geniuz-embed.sock
+//! Cross-platform IPC server via interprocess crate:
+//!   Unix/macOS: Unix domain socket
+//!   Windows:    Named pipe
 //! Protocol: send text (u32 LE length prefix + UTF-8 bytes), receive 1536 bytes (384 × f32 LE)
 //! Auto-exits after idle timeout (default 5 min, configurable via GENIUZ_EMBED_IDLE)
 
 use std::io::{Read, Write};
-use std::os::unix::net::UnixListener;
-use std::path::Path;
 use std::time::{Duration, Instant};
+
+use interprocess::local_socket::{
+    prelude::*, GenericNamespaced, ListenerOptions, ToNsName,
+};
 
 use geniuz::embedding;
 
-const DEFAULT_SOCKET: &str = "/tmp/geniuz-embed.sock";
+const DEFAULT_NAME: &str = "geniuz-embed.sock";
 const DEFAULT_IDLE_SECS: u64 = 300;
 const EMBEDDING_BYTES: usize = 384 * 4;
 
 fn main() {
-    let socket_path = std::env::var("GENIUZ_EMBED_SOCKET")
-        .unwrap_or_else(|_| DEFAULT_SOCKET.to_string());
+    let name = std::env::var("GENIUZ_EMBED_SOCKET")
+        .unwrap_or_else(|_| DEFAULT_NAME.to_string());
     let idle_secs = std::env::var("GENIUZ_EMBED_IDLE")
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(DEFAULT_IDLE_SECS);
 
-    // Clean up stale socket
-    if Path::new(&socket_path).exists() {
-        if std::os::unix::net::UnixStream::connect(&socket_path).is_ok() {
-            eprintln!("[geniuz-embed] Already running at {}", socket_path);
-            std::process::exit(0);
+    let ns_name = match name.as_str().to_ns_name::<GenericNamespaced>() {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("[geniuz-embed] Bad socket name {}: {}", name, e);
+            std::process::exit(1);
         }
-        let _ = std::fs::remove_file(&socket_path);
+    };
+
+    // Check if already running (try connecting)
+    if interprocess::local_socket::Stream::connect(ns_name.clone()).is_ok() {
+        eprintln!("[geniuz-embed] Already running at {}", name);
+        std::process::exit(0);
     }
 
     // Load ONNX backend (one-time cost)
@@ -44,16 +53,20 @@ fn main() {
         }
     };
 
-    let listener = match UnixListener::bind(&socket_path) {
+    let listener = match ListenerOptions::new()
+        .name(ns_name)
+        .create_sync()
+    {
         Ok(l) => l,
         Err(e) => {
             eprintln!("[geniuz-embed] Bind failed: {}", e);
             std::process::exit(1);
         }
     };
-    listener.set_nonblocking(true).expect("set_nonblocking");
+    listener.set_nonblocking(interprocess::local_socket::ListenerNonblockingMode::Both)
+        .expect("set_nonblocking");
 
-    eprintln!("[geniuz-embed] {} (idle: {}s)", socket_path, idle_secs);
+    eprintln!("[geniuz-embed] {} (idle: {}s)", name, idle_secs);
 
     let mut last_activity = Instant::now();
     let idle_timeout = Duration::from_secs(idle_secs);
@@ -61,11 +74,8 @@ fn main() {
 
     loop {
         match listener.accept() {
-            Ok((mut stream, _)) => {
+            Ok(mut stream) => {
                 last_activity = Instant::now();
-
-                // Set read timeout so a stalled client can't hang the server
-                let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
 
                 // Read u32 LE length prefix
                 let mut len_buf = [0u8; 4];
@@ -112,6 +122,4 @@ fn main() {
             }
         }
     }
-
-    let _ = std::fs::remove_file(&socket_path);
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -282,14 +282,15 @@ pub fn serve() {
 // =============================================================================
 
 fn config_path() -> std::path::PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    if cfg!(target_os = "macos") {
-        std::path::PathBuf::from(home)
-            .join("Library/Application Support/Claude/claude_desktop_config.json")
-    } else {
-        std::path::PathBuf::from(home)
-            .join(".config/Claude/claude_desktop_config.json")
-    }
+    // dirs::config_dir() returns the right base on every platform:
+    //   macOS:   ~/Library/Application Support
+    //   Windows: %APPDATA%        (C:\Users\<u>\AppData\Roaming)
+    //   Linux:   ~/.config        (XDG_CONFIG_HOME or default)
+    // All three are where Claude Desktop reads its config from.
+    dirs::config_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join("Claude")
+        .join("claude_desktop_config.json")
 }
 
 fn geniuz_binary_path() -> String {


### PR DESCRIPTION
## Why

`embed_client.rs` and `embed_server.rs` used `std::os::unix::net::UnixStream`/`UnixListener` for IPC between the CLI and the `geniuz-embed` warm-ONNX subprocess. Unix-only API. Doesn't compile on Windows. First and only blocker discovered when attempting `cargo build --release --target x86_64-pc-windows-msvc` on a fresh Windows 11 machine.

## What

Replace direct UDS usage with the [`interprocess`](https://crates.io/crates/interprocess) crate's `local_socket` abstraction. The crate routes to the right native primitive per platform:

- **Unix/macOS:** Unix domain socket (existing behavior, unchanged for users)
- **Windows:** Named Pipe (kernel-mediated IPC, no firewall surface)

Same wire protocol on both sides (`u32` LE length prefix + UTF-8 bytes; 1536-byte response). Same auto-spawn semantics. Same env vars.

## Why this UX choice (Path C, after consulting Lemonade)

Two alternatives considered and rejected:
- **Path A — TCP localhost everywhere:** simplest code, but triggers a first-run firewall prompt on macOS and Windows ("Do you want geniuz-embed to accept incoming network connections?"). Visible to `netstat` and Little Snitch. The dialog is technically correct and semantically devastating to the "nothing leaves your machine" pitch.
- **Path B — Conditional compilation, UDS on Unix + TCP on Windows:** Mac/Linux unchanged, but Windows users get the degraded experience.
- **Path C (this PR) — `interprocess` crate:** zero firewall prompt on any platform, invisible to `netstat`, one code path, one new dependency. The privacy pitch matches the implementation without requiring user trust or a footnote.

## Tested

- ✅ **Mac** (`cargo check` clean, no warnings)
- ✅ **Windows** (Orbit, `x86_64-pc-windows-msvc`):
  - `cargo build --release` clean
  - `geniuz remember` — saved memory with semantic embedding
  - `geniuz recall` — semantic search returned matching result with relevance score 0.465
  - `geniuz recent` — listed memories
  - ONNX Runtime `download-binaries` resolved `onnxruntime.dll` for Windows automatically
  - HuggingFace model auto-download on first use worked
  - **No Windows Firewall prompt** observed during the test (Named Pipes confirmed silent)
  - Memory stored at `C:\Users\<user>\.geniuz\memory.db` (the `dirs` crate handled the cross-platform home-directory abstraction with no code changes)

## Diff size

Three source files, ~99 insertions / 56 deletions. Most of the diff is identical structure with `UnixStream` → `Stream`, `UnixListener` → `ListenerOptions`, plus removal of the explicit socket-file cleanup logic (no longer needed; `interprocess` handles namespace lifecycle on each platform).

## Follow-ups (not in this PR)

- NSIS installer for Windows
- Code signing (Authenticode cert procurement)
- `geniuz mcp install` verification on Windows (writes `%APPDATA%\Claude\claude_desktop_config.json`)
- Optional: Rust system-tray app for Windows (parity with Mac menu bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Limen <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch IPC between the CLI and `geniuz-embed` to cross‑platform local sockets via `interprocess`, enabling Windows (Named Pipes) while keeping Unix/macOS (UDS) and avoiding firewall prompts. Add a per‑user Windows installer that adds PATH and wires Claude Desktop; also fix the Claude Desktop config path on Windows.

- New Features
  - Cross-platform IPC: UDS on Unix/macOS, Named Pipes on Windows (no firewall prompt).
  - Same wire protocol and auto-spawn; `GENIUZ_EMBED_SOCKET` still supported.
  - Simplified lifecycle: no socket-file cleanup; liveness via connect; nonblocking listener.
  - Windows installer (`installer/windows/Geniuz.iss`): per-user, adds to PATH, runs `geniuz mcp install`.

- Bug Fixes
  - Correct Claude Desktop config path using `dirs::config_dir()`, so `geniuz mcp install` writes to `%APPDATA%\Claude\claude_desktop_config.json` on Windows.

<sup>Written for commit aee254efe58cb7228ad3587e3e66127c57d54ea3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

