### PR TITLE
v1.0.4: user-chosen data dir + sandbox-friendly ACLs (fixes Store Claude disconnect)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "geniuz"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geniuz"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 description = "Your AI remembers now — persistent memory for AI agents"
 license = "MIT"

--- a/installer/windows/Geniuz.iss
+++ b/installer/windows/Geniuz.iss
@@ -103,7 +103,8 @@ begin
     False, ''
   );
   DataDirPage.Add('');
-  DataDirPage.Values[0] := ExpandConstant('{userprofile}\.geniuz');
+  // Inno Setup has no {userprofile} constant; use the env-var expansion syntax.
+  DataDirPage.Values[0] := ExpandConstant('{%USERPROFILE}\.geniuz');
 end;
 
 function GetDataDir(Param: string): string;

--- a/installer/windows/Geniuz.iss
+++ b/installer/windows/Geniuz.iss
@@ -1,8 +1,19 @@
 ; Geniuz Free for Windows — Inno Setup installer script
-; Per-user install (no admin), matches the philosophy of "your AI on your machine"
+;
+; Per-user install only. Memory is per-user by design (your memories aren't
+; your colleague's memories), and per-user install sidesteps the all-users
+; ambiguity where the installer can't pre-create per-user data dirs for
+; users who haven't logged in yet.
+;
+; The user picks the data directory (memory.db location) during install.
+; Default: %USERPROFILE%\.geniuz. The installer creates the chosen dir in
+; user context (no sandbox restriction) and grants ALL APPLICATION PACKAGES
+; write access — so when sandboxed Claude Desktop later launches geniuz as
+; a child process, it can read/write the database without a sandbox-denied
+; mkdir failure.
 
 #define MyAppName "Geniuz"
-#define MyAppVersion "1.0.3"
+#define MyAppVersion "1.0.4"
 #define MyAppPublisher "Managed Ventures LLC"
 #define MyAppURL "https://geniuz.life"
 #define MyAppExeName "geniuz.exe"
@@ -21,8 +32,8 @@ AppComments={#MyAppDescription}
 DefaultDirName={localappdata}\Programs\Geniuz
 DefaultGroupName=Geniuz
 DisableProgramGroupPage=yes
+; Per-user install only — no admin elevation, no all-users option.
 PrivilegesRequired=lowest
-PrivilegesRequiredOverridesAllowed=dialog
 OutputDir=output
 OutputBaseFilename=Geniuz-Setup
 Compression=lzma2
@@ -32,10 +43,6 @@ ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 UninstallDisplayName={#MyAppName}
 UninstallDisplayIcon={app}\Geniuz.ico
-; Geniuz.ico is multi-resolution (16/32/48/64/128/256). Used as:
-;   - The installer .exe icon (SetupIconFile)
-;   - The Add/Remove Programs entry icon (UninstallDisplayIcon → file in install dir)
-;   - The uninstaller .exe icon (auto-derived from SetupIconFile by Inno)
 SetupIconFile=Geniuz.ico
 
 [Languages]
@@ -46,25 +53,64 @@ Source: "geniuz.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "geniuz-embed.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "Geniuz.ico"; DestDir: "{app}"; Flags: ignoreversion
 
+[Dirs]
+; Create the user-chosen data directory in user context (no sandbox issue).
+Name: "{code:GetDataDir}"
+
 [Registry]
-; Add install dir to user PATH (only if not already present)
+; Add install dir to user PATH (only if not already present).
 Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; \
   ValueData: "{olddata};{app}"; \
   Check: NeedsAddPath('{app}')
+; Persist the user's data directory choice as an environment variable.
+; This lets the CLI (from any future shell) and external tools discover
+; where memories live without parsing the Claude Desktop config.
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "GENIUZ_HOME"; \
+  ValueData: "{code:GetDataDir}"
 
 [Run]
-; Wire Claude Desktop MCP config. The CLI (v1.0.2+) now writes to all known
-; Claude Desktop config locations:
-;   - %APPDATA%\Claude\         (the .exe variant)
-;   - %LOCALAPPDATA%\Packages\Claude_*\LocalCache\Roaming\Claude\
-;     (the Microsoft Store / MSIX packaged variant)
-; This is much more robust than v1.0.1, which only wrote the standard path
-; and silently missed Store-version Claude users.
-Filename: "{app}\{#MyAppExeName}"; Parameters: "mcp install"; \
+; Grant ALL APPLICATION PACKAGES (S-1-15-2-1) read+write on the data dir.
+; Without this, sandboxed Claude Desktop can launch geniuz.exe but the
+; child can't access the database file → "Geniuz Disconnected" in Claude.
+; (OI)(CI)F = object inherit + container inherit + full control on contents.
+Filename: "{sys}\icacls.exe"; \
+  Parameters: """{code:GetDataDir}"" /grant ""*S-1-15-2-1:(OI)(CI)M"""; \
+  StatusMsg: "Granting sandboxed apps access to memory folder..."; \
+  Flags: runhidden
+
+; Wire Claude Desktop MCP config. Pass GENIUZ_HOME so the entry includes
+; the env block — important on Windows because sandboxed Claude doesn't
+; inherit the user's HKCU environment; the path has to be embedded in the
+; MCP config itself.
+Filename: "{app}\{#MyAppExeName}"; \
+  Parameters: "mcp install --env GENIUZ_HOME=""{code:GetDataDir}"""; \
   StatusMsg: "Configuring Claude Desktop integration..."; \
   Flags: runhidden
 
 [Code]
+var
+  DataDirPage: TInputDirWizardPage;
+
+procedure InitializeWizard;
+begin
+  DataDirPage := CreateInputDirPage(
+    wpSelectDir,
+    'Memory location',
+    'Where should Geniuz keep your memories?',
+    'Geniuz keeps your memories — and the embedding model that searches them — in this folder.' + #13#10 + #13#10 +
+    'The default works for most people. You can change it to any folder you have rights to write — for example a different drive, or a synced folder if you want memories across machines.' + #13#10 + #13#10 +
+    'You can change this later by editing the GENIUZ_HOME environment variable.',
+    False, ''
+  );
+  DataDirPage.Add('');
+  DataDirPage.Values[0] := ExpandConstant('{userprofile}\.geniuz');
+end;
+
+function GetDataDir(Param: string): string;
+begin
+  Result := DataDirPage.Values[0];
+end;
+
 function NeedsAddPath(Param: string): Boolean;
 var
   OrigPath: string;
@@ -87,15 +133,17 @@ begin
   if CurUninstallStep = usUninstall then
   begin
     AppDir := ExpandConstant('{app}');
+    // PATH cleanup
     if RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', OrigPath) then
     begin
-      // Remove ;AppDir from PATH (idempotent, case-insensitive).
-      // StringChangeEx mutates the var-string and returns Integer (count).
       NewPath := OrigPath;
       StringChangeEx(NewPath, ';' + AppDir, '', True);
       StringChangeEx(NewPath, AppDir + ';', '', True);
       StringChangeEx(NewPath, AppDir, '', True);
       RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', NewPath);
     end;
+    // Remove the GENIUZ_HOME pointer. We do NOT delete the data directory
+    // itself — user memories survive uninstall by design.
+    RegDeleteValue(HKEY_CURRENT_USER, 'Environment', 'GENIUZ_HOME');
   end;
 end;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -179,9 +179,14 @@ pub enum McpCommand {
 
     /// Install Geniuz into Claude Desktop config
     #[command(
-        after_help = "Adds Geniuz as an MCP server in Claude Desktop's config file.\nAfter running this, restart Claude Desktop to activate.\n\nYour Claude will have three new tools: remember, recall, recent."
+        after_help = "Adds Geniuz as an MCP server in Claude Desktop's config file.\nAfter running this, restart Claude Desktop to activate.\n\nYour Claude will have three new tools: remember, recall, recent.\n\nUse --env KEY=VALUE to embed environment variables in the MCP entry —\nthe Windows installer uses this to pass GENIUZ_HOME so the sandboxed\nClaude knows where the user's data directory lives."
     )]
-    Install,
+    Install {
+        /// Embed an environment variable in the MCP server entry. Repeatable.
+        /// Example: --env GENIUZ_HOME=C:\Users\jackc\.geniuz
+        #[arg(long, value_name = "KEY=VALUE")]
+        env: Vec<String>,
+    },
 
     /// Check if Geniuz is configured in Claude Desktop
     Status,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,25 +22,43 @@ fn main() {
     }
 }
 
+/// User's home directory, cross-platform.
+/// On Windows this is %USERPROFILE% (HOME is not standard there).
+fn home_dir() -> PathBuf {
+    dirs::home_dir().unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// Resolve the Geniuz data directory. Precedence:
+///   1. GENIUZ_HOME env var (set by the installer's directory picker, or by the user)
+///   2. ~/.geniuz on every platform
+///
+/// The data directory holds memory.db, the embedding model cache, and any other
+/// per-user state. The user can pick this location at install time so the dir
+/// is created in user context (no sandbox restrictions) and remains accessible
+/// from sandboxed Claude Desktop child processes.
+pub fn data_dir() -> PathBuf {
+    std::env::var("GENIUZ_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| home_dir().join(".geniuz"))
+}
+
 fn default_db_path() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".geniuz").join("memory.db")
+    data_dir().join("memory.db")
 }
 
 fn default_claw_workspace() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".openclaw").join("workspace")
+    home_dir().join(".openclaw").join("workspace")
 }
 
 pub fn get_db() -> Result<db::DatabaseManager, String> {
-    // Check env vars: GENIUZ_STATION first, CLAWMARK_STATION as legacy fallback
+    // Precedence: GENIUZ_STATION (explicit DB file path) > GENIUZ_HOME-derived default
+    //             > legacy ~/.geniuz/station.db > legacy ~/.clawmark/station.db
     let path = std::env::var("GENIUZ_STATION")
         .or_else(|_| std::env::var("CLAWMARK_STATION"))
         .unwrap_or_else(|_| {
-            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
             let new_path = default_db_path();
-            let geniuz_legacy = PathBuf::from(&home).join(".geniuz").join("station.db");
-            let clawmark_legacy = PathBuf::from(&home).join(".clawmark").join("station.db");
+            let geniuz_legacy = home_dir().join(".geniuz").join("station.db");
+            let clawmark_legacy = home_dir().join(".clawmark").join("station.db");
 
             if new_path.exists() {
                 new_path.to_string_lossy().to_string()
@@ -519,8 +537,8 @@ fn run(cli: Cli) -> Result<String, String> {
                     mcp::serve();
                     Ok(String::new())
                 }
-                McpCommand::Install => {
-                    mcp::install()
+                McpCommand::Install { env } => {
+                    mcp::install(&env)
                 }
                 McpCommand::Status => {
                     mcp::status()

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -345,14 +345,29 @@ fn geniuz_binary_path() -> String {
         .unwrap_or_else(|_| "geniuz".to_string())
 }
 
-pub fn install() -> Result<String, String> {
+/// Parse `KEY=VALUE` strings into a JSON object suitable for the MCP
+/// server entry's `env` block. Skips malformed entries with a warning.
+fn parse_env_args(env_args: &[String]) -> serde_json::Map<String, serde_json::Value> {
+    let mut env_map = serde_json::Map::new();
+    for entry in env_args {
+        if let Some((k, v)) = entry.split_once('=') {
+            env_map.insert(k.to_string(), serde_json::Value::String(v.to_string()));
+        } else {
+            eprintln!("[geniuz mcp install] Ignoring malformed --env (expected KEY=VALUE): {}", entry);
+        }
+    }
+    env_map
+}
+
+pub fn install(env_args: &[String]) -> Result<String, String> {
     let binary = geniuz_binary_path();
+    let env_map = parse_env_args(env_args);
     let paths = config_paths();
     let mut written = Vec::new();
     let mut errors = Vec::new();
 
     for config_file in &paths {
-        match install_to_path(config_file, &binary) {
+        match install_to_path(config_file, &binary, &env_map) {
             Ok(()) => written.push(config_file.clone()),
             Err(e) => errors.push(format!("{}: {}", config_file.display(), e)),
         }
@@ -406,7 +421,11 @@ pub fn install() -> Result<String, String> {
 
 /// Read-modify-write a single Claude Desktop config file: load existing JSON
 /// (or start fresh if absent), upsert the Geniuz MCP entry, write back.
-fn install_to_path(config_file: &std::path::Path, binary: &str) -> Result<(), String> {
+fn install_to_path(
+    config_file: &std::path::Path,
+    binary: &str,
+    env_map: &serde_json::Map<String, serde_json::Value>,
+) -> Result<(), String> {
     let mut config: serde_json::Value = if config_file.exists() {
         let content = std::fs::read_to_string(config_file)
             .map_err(|e| format!("read failed: {}", e))?;
@@ -423,10 +442,15 @@ fn install_to_path(config_file: &std::path::Path, binary: &str) -> Result<(), St
     if config.get("mcpServers").is_none() {
         config["mcpServers"] = serde_json::json!({});
     }
-    config["mcpServers"]["Geniuz"] = serde_json::json!({
+
+    let mut entry = serde_json::json!({
         "command": binary,
         "args": ["mcp", "serve"]
     });
+    if !env_map.is_empty() {
+        entry["env"] = serde_json::Value::Object(env_map.clone());
+    }
+    config["mcpServers"]["Geniuz"] = entry;
 
     let formatted = serde_json::to_string_pretty(&config)
         .map_err(|e| format!("serialize failed: {}", e))?;


### PR DESCRIPTION
## Why

v1.0.3 install on a fresh Windows account showed Claude Desktop reporting "Geniuz Disconnected" even though config wiring was correct. Root cause from `mcp-server-Geniuz.log`:

```
[geniuz] Failed to open station: Failed to create directory: Access is denied. (os error 5)
```

When Microsoft Store Claude Desktop launched `geniuz.exe` as a child process, geniuz tried to mkdir `~/.geniuz/` and the AppContainer sandbox blocked it. Even though the user has rights to their home folder, sandboxed children can't create new dirs there.

## Paradigm shift

Stop having geniuz create its data dir at runtime. Have the **installer** create it in non-sandboxed user context, with sandbox-friendly ACLs. The user picks the location at install time so they have agency over where their memories live.

## Changes

**CLI** (`src/main.rs`, `src/cli.rs`, `src/mcp.rs`):
- New `data_dir()` honors `GENIUZ_HOME` env var, falls back to `~/.geniuz`
- `dirs::home_dir()` replaces `HOME` env var lookups (HOME isn't standard on Windows; USERPROFILE is — `dirs` handles cross-platform)
- `geniuz mcp install` accepts `--env KEY=VALUE` (repeatable) so the installer can embed `GENIUZ_HOME` in the Claude Desktop MCP config's `env` block. Sandboxed Claude doesn't inherit HKCU env, so the path must live in the config itself.

**Installer** (`installer/windows/Geniuz.iss`):
- Per-user install only. Memory is per-user by design; the all-users option created the install-time-vs-runtime user-identity ambiguity that made v1.0.3 fragile.
- New "Memory location" wizard page — user picks the data dir, default `%USERPROFILE%\.geniuz`. Because they pick it in non-sandboxed installer context, they can pick anywhere they have rights.
- `[Dirs]` creates the chosen dir.
- `[Run]` icacls grants `ALL APPLICATION PACKAGES` (S-1-15-2-1) Modify on the dir → sandboxed Claude's geniuz child can read+write.
- `[Registry]` sets `HKCU\Environment\GENIUZ_HOME = chosen path` (one transparent config registry value, IT-acceptable).
- `geniuz mcp install --env GENIUZ_HOME=...` writes the path into Claude Desktop's MCP entry env block.
- Uninstaller removes `GENIUZ_HOME` registry entry but **preserves the data directory** — user memories survive uninstall by design.

## What enterprise IT sees

- `HKCU\Environment\Path` (necessary, was already there)
- `HKCU\Environment\GENIUZ_HOME` (one config value, transparent)
- Filesystem activity scoped to per-user install dir + per-user data dir
- No HKLM, no Run-once, no scheduled tasks, no automation

## Tested

- ✅ Mac: `cargo check` clean
- ✅ Windows orbit account silent install:
  - `HKCU\Environment\GENIUZ_HOME` = `C:\Users\orbit\.geniuz` ✓
  - Data dir created with `ALL APPLICATION PACKAGES Modify` ACL ✓
  - Claude Desktop config has `env: { GENIUZ_HOME: ... }` block ✓
- ⏳ Pending real-world test on jackc account where Microsoft Store Claude is the actual MCP host

## What this unlocks

- Sandboxed Claude can finally read+write Geniuz's memory database
- Users get explicit control over where their memories live
- Same install works whether Claude is .exe or Store version
- Enterprise deployers can pre-set `GENIUZ_HOME` via Group Policy if they want a standard location across all users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Limen <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a user-chosen data directory and sandbox-friendly ACLs so Claude Desktop (including the Microsoft Store version) can read/write Geniuz data without disconnects. The installer now sets `GENIUZ_HOME`, and the CLI honors it for consistent paths.

- **New Features**
  - Per-user installer adds a “Memory location” picker. Creates the folder, grants `ALL APPLICATION PACKAGES` Modify, sets `HKCU\Environment\GENIUZ_HOME`, and embeds it in Claude’s MCP config.
  - CLI resolves the data dir via `GENIUZ_HOME`, falling back to `~/.geniuz` using `dirs::home_dir()`. `geniuz mcp install` now supports `--env KEY=VALUE`.
  - Uninstaller removes `GENIUZ_HOME` but keeps the data folder.

- **Bug Fixes**
  - Fixes “Access is denied” when sandboxed Claude launches `geniuz.exe`, eliminating “Geniuz Disconnected” for Microsoft Store and .exe installs.

<sup>Written for commit 6f2b8d3120737e74947b6242ef1d858c27f13eaa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

