### PR TITLE
2.0.5: Windows NSIS installer icon + tray tooltip

### DIFF
--- a/desktop/dashboard/src/lib.rs
+++ b/desktop/dashboard/src/lib.rs
@@ -504,6 +504,7 @@ pub fn run() {
 
                 let _tray = TrayIconBuilder::new()
                     .icon(app.default_window_icon().cloned().expect("default window icon"))
+                    .tooltip("Geniuz")
                     .menu(&tray_menu)
                     .show_menu_on_left_click(false)
                     .on_menu_event(|app, event| {

--- a/desktop/dashboard/tauri.conf.json
+++ b/desktop/dashboard/tauri.conf.json
@@ -45,6 +45,9 @@
     "windows": {
       "webviewInstallMode": {
         "type": "downloadBootstrapper"
+      },
+      "nsis": {
+        "installerIcon": "icons/icon.ico"
       }
     }
   },


### PR DESCRIPTION
## Summary

Two small polish items for v2.0.5, drafted on a feature branch so nothing ships until you review.

- `bundle.windows.nsis.installerIcon` → `icons/icon.ico`. Windows `Geniuz-Setup.exe` will show the Geniuz icon instead of the generic NSIS default. WiX doesn't expose an installer-icon field in tauri.conf.json — the MSI uses the icon embedded in the bundled `.exe`.
- `TrayIconBuilder.tooltip("Geniuz")` — Windows/Linux tray icon now has a hover label. macOS branch unchanged (`#[cfg(not(target_os = "macos"))]`-gated).

Both changes only take effect when Windows is rebuilt (next tag → orbit `cargo tauri build`). Mac and Linux v2.0.4 binaries are unaffected. `cargo check` clean on mars.

Built autonomously while you were at the post office; loop heartbeat `3db7cde6` at :07/:22/:37/:52.

## Test plan

- [ ] On orbit: `cargo tauri build` produces NSIS installer with Geniuz icon
- [ ] Run installer; confirm icon shows in installer UI + uninstaller in Apps & Features
- [ ] Run dashboard on Windows; hover tray icon → "Geniuz" tooltip appears
- [ ] On Linux galaxy: hover tray icon → tooltip appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Geniuz icon to the Windows NSIS installer and a hover tooltip for the tray icon on Windows/Linux. Improves brand recognition and usability; macOS unchanged.

- New Features
  - Windows: set `bundle.windows.nsis.installerIcon` to `icons/icon.ico` so `Geniuz-Setup.exe` and the uninstaller show the app icon.
  - Tray: add `.tooltip("Geniuz")` for Windows/Linux (non-macOS path only).

<sup>Written for commit e0904725577033c0ed278d7afe2ed0a7561ad170. Summary will update on new commits. <a href="https://cubic.dev/pr/jackccrawford/Geniuz/pull/21?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

